### PR TITLE
Add the homepage from docs.jujucharms.com

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+
+{% block body %}
+  <div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/bd1d8c1d-juju-suru-blue-background.png')">
+    <div class="p-content__row">
+      <h1>Juju Documentation</h1>
+      <p class="p-heading--four">Juju is an open source application modeling tool. It allows you to deploy, configure, scale and operate your software on public and private clouds.</p>
+    </div>
+  </div>
+
+  <div class="p-strip">
+    <div class="p-content__row">
+      <div class="u-equal-height">
+        <div class="col-6">
+          <h2>Getting started</h2>
+          <p><a href="/getting-started-with-juju/1134">Getting started with Juju&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="col-6 u-align--right">
+          <img style="border: 0" src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg">
+        </div>
+      </div>
+      <hr class="is-deep">
+      <div class="u-equal-height">
+        <div class="col-6">
+          <h2>What's new</h2>
+          <ul class="p-list">
+            <li class="p-list__item"><a href="/whats-new-in-2-5/1202">New features in 2.5&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/using-lxd-with-juju-advanced/1091">Remote and clustered LXD clouds&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/using-oracle-oci-with-juju/1096">Oracle OCI cloud support&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/using-kubernetes-with-juju/1090">Using Kubernetes with Juju&nbsp;&rsaquo;</a></li>
+          </ul>
+        </div>
+        <div class="col-6">
+          <h2>Doc updates</h2>
+          <ul class="p-list">
+            <li class="p-list__item"><a href="/basic-client-usage-tutorial/1191">Basic client usage&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/using-the-aws-integrator-charm-tutorial/1192">Using the aws-integrator charm&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/multi-user-basic-setup-tutorial/1195">Multi-user basic setup&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/using-juju-with-microk8s-tutorial/1194">Using Juju with MicroK8s&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/setting-up-static-kubernetes-storage-tutorial/1193">Setting up static Kubernetes storage&nbsp;&rsaquo;</a></li>
+          </ul>
+        </div>
+      </div>
+      <hr class="is-deep">
+      <div class="u-equal-height">
+        <div class="col-6">
+          <h2>Getting support</h2>
+          <ul class="p-list is-split">
+            <li class="p-list__item">
+              <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/039628d5-picto-community-orange.svg');
+              height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+              <a class="p-link--external" href="https://jujucharms.com/community">Community</a>
+            </li>
+            <li class="p-list__item">
+              <i class="p-icon"
+                  style="background-image:url('https://assets.ubuntu.com/v1/fa38eb81-picto-business-midaubergine.svg');
+                        height:1.5rem;width: 1.5rem;top:
+                        2px;margin-right:.5rem;"></i>
+              <a href="/managed-solutions/1132">Managed solutions</a>
+            </li>
+            <li class="p-list__item">
+              <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/4ef84d88-picto-quote-warmgrey.svg');
+              height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+              <a class="p-link--external" href="https://blog.ubuntu.com/tag/juju">Blog</a>
+            </li>
+            <li class="p-list__item">
+              <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg');
+              height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+              <a class="p-link--external" href="http://askubuntu.com/questions/tagged/juju">Ask a question</a>
+            </li>
+            <li class="p-list__item">
+              <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/422b612c-picto-forum-warmgrey.svg');
+              height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+              <a class="p-link--external" href="https://ubuntuforums.org/forumdisplay.php?f=392">Forum</a>
+            </li>
+            <li class="p-list__item">
+              <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+              height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+              <a class="p-link--external" href="http://webchat.freenode.net/?channels=%23juju">Freenode</a>
+            </li>
+          </ul>
+        </div>
+        <div class="col-6">
+          <h2>Contribute</h2>
+          <ul class="p-list">
+            <li class="p-list__item"><a class="p-link--external" href="https://github.com/juju/juju">Help improve Juju</a></li>
+            <li class="p-list__item--deep"><a class="p-link--external" href="https://discourse.jujucharms.com/t/documentation-guidelines/1245">Help improve the documentation</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -86,16 +86,21 @@ def clear_trailing():
 @app.route("/")
 def homepage():
     """
-    Redirect to the frontpage topic
+    Show the custom homepage
     """
 
-    frontpage, nav_html = discourse.parse_frontpage()
+    intro, nav_html = discourse.parse_frontpage()
 
-    return flask.redirect(frontpage["path"])
+    return flask.render_template("homepage.html", nav_html=nav_html)
 
 
 @app.route("/<path:path>")
 def document(path):
+    # Redirect frontpage topic to homepage
+    if path.endswith(f"/{discourse.frontpage_id}"):
+        return flask.redirect("/")
+
+    # Get document
     try:
         document, nav_html = discourse.get_document(path)
     except RedirectFoundError as redirect_error:
@@ -106,6 +111,7 @@ def document(path):
         document = nav_error.document
         nav_html = f"<p>{str(nav_error)}</p>"
 
+    # Render document
     return flask.render_template(
         "document.html",
         title=document["title"],


### PR DESCRIPTION
**This PR is based on #6 - merge that first**

This homepage, rather than being pulled from discourse, will be served as custom HTML, so we can maintain the prettier styling.

I've also made it so browsing to the actual homepage topic will redirect you to this custom homepage.

Fixes https://github.com/ubuntudesign/base-squad/issues/432

QA
--

`./run`, go to https://0.0.0.0:8030, see that the homepage looks like it does on https://docs.jujucharms.com/2.5/en/, except that the link have changed to point to the new locations of the same pages.

Go to http://0.0.0.0:8030/juju-documentation/1087, (the frontpage topic, with the nav in it) - see you're redirected to `/` and see the new homepage.