### PR TITLE
Update header to match jaas.ai

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -200,38 +200,38 @@
             <button type="reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
             <button type="submit" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
           </form>
-          
-          
+
           <ul class="p-navigation__links" role="menu">
-            
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/store">Store</a>
+              <a href="https://jujucharms.com/store" class="">
+                Store
+              </a>
             </li>
-            
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/how-it-works">How it works</a>
+              <a href="https://jujucharms.com/jaas" class="">
+                About
+              </a>
             </li>
-            
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/jaas">JAAS</a>
+              <a href="https://jujucharms.com/how-it-works" class="">
+                How it works
+              </a>
             </li>
-            
+            <li class="p-navigation__link is-secondary-link" role="menuitem">
+              <a class="p-link--external" href="https://discourse.jujucharms.com/">
+                Discourse
+              </a>
+            </li>
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/experts">Experts</a>
+              <a class="p-link--external" href="/">
+                Docs
+              </a>
             </li>
-            
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/community">Community</a>
+              <a class="p-link--external" href="https://jujucharms.com/new/">
+                Your models
+              </a>
             </li>
-            
-            <li class="p-navigation__link" role="menuitem">
-              <a href="/">Docs</a>
-            </li>
-            
-            <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/new/?dd=cs:bundle/canonical-kubernetes">Try the beta</a>
-            </li>
-            
           </ul>
           
           <span class="u-off-screen">


### PR DESCRIPTION
***NB: This is based on https://github.com/canonical-web-and-design/docs.jujucharms.com/pull/13 - review & merge that first***

I've copied the items from the https://jaas.ai nav, except that instead of linking to jaas.ai, I'm linking to jujucharms.com. This is because this site will likely go live before the unveiling of jaas.ai, and so the public should, for the time being, still be sent to jujucharms.com. When jaas.ai is unveiled, these URLs will redirects to jaas.ai anyway.

Fixes https://github.com/canonical-web-and-design/base-squad/issues/509

QA
--

`./run`, go to http://0.0.0.0:8033, see that the items in the nav are the same ones as in the jaas.ai nav.