### PR TITLE
Fix nav styling on Chrome

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -203,34 +203,22 @@
 
           <ul class="p-navigation__links" role="menu">
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/store" class="">
-                Store
-              </a>
+              <a href="https://jujucharms.com/store" class="">Store</a>
             </li>
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/jaas" class="">
-                About
-              </a>
+              <a href="https://jujucharms.com/jaas" class="">About</a>
             </li>
             <li class="p-navigation__link" role="menuitem">
-              <a href="https://jujucharms.com/how-it-works" class="">
-                How it works
-              </a>
+              <a href="https://jujucharms.com/how-it-works" class="">How it works</a>
             </li>
             <li class="p-navigation__link is-secondary-link" role="menuitem">
-              <a class="p-link--external" href="https://discourse.jujucharms.com/">
-                Discourse
-              </a>
+              <a class="p-link--external" href="https://discourse.jujucharms.com/">Discourse</a>
             </li>
             <li class="p-navigation__link" role="menuitem">
-              <a class="p-link--external" href="/">
-                Docs
-              </a>
+              <a class="p-link--external" href="/">Docs</a>
             </li>
             <li class="p-navigation__link" role="menuitem">
-              <a class="p-link--external" href="https://jujucharms.com/new/">
-                Your models
-              </a>
+              <a class="p-link--external" href="https://jujucharms.com/new/">Your models</a>
             </li>
           </ul>
           


### PR DESCRIPTION
Removing the whitespace fixes the broken nav.

![broken-nav](https://user-images.githubusercontent.com/519935/57178709-9a8d8500-6e6c-11e9-8326-2aba8ff71287.png)

becomes

![better-nav](https://user-images.githubusercontent.com/519935/57178714-9eb9a280-6e6c-11e9-9eaf-9c4534488ec4.png)

QA
--

`./run`, go to http://0.0.0.0:8033/ in Chrome, see the nav looking pretty.