### PR TITLE
Fix redirects for `/devel`, `/stable` etc.

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,6 +1,7 @@
 (?P<version>1\.[0-9]{1,2}|2\.0|2\.1|2\.2|2\.3|2\.4|2\.5)(?P<path>.*): https://old-docs.jujucharms.com/{version}{path}
 
 # Redirect /devel, /stable, /en (from old sitemap) to /
+(devel|stable|en|devel/en|stable/en): /
 (devel|stable|en|devel/en|stable/en)/(?P<path>.*): /{path}
 
 # Remove HTML extensions


### PR DESCRIPTION
URLs like https://docs.jujucharms.com/stable, https://docs.jujucharms.com/devel lead to 404. They should redirec to the homepage.

QA
--

`./run`

Check these URLs redirect:

- http://0.0.0.0:8033/stable
- http://0.0.0.0:8033/stable/en
- http://0.0.0.0:8033/devel
- http://0.0.0.0:8033/devel/en
- http://0.0.0.0:8033/devel/en/about-juju

Also, just browse around a bit, check the site works.