### PR TITLE
Bump canonicalwebteam.discourse-docs to 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Flask==1.0.2
 canonicalwebteam.http==0.1.6
 canonicalwebteam.yaml_responses[flask]==1.1.0
-canonicalwebteam.discourse-docs==0.3.0
+canonicalwebteam.discourse-docs==0.4.0
 requests-mock==1.5.2
 requests-cache==0.4.13
 beautifulsoup4==4.7.1


### PR DESCRIPTION
## Done
Bumps the discourse extension to 0.4.0 so when you try to access topics
that do not belong to the docs category you are redirected to the forum.

## QA
- Go to `/1451` and make sure you are redirected to `https://discourse.jujucharms.com/t/thoughts-on-unit-testing/1451`

- Go to `/thoughts-on-unit-testing/1451` and make sure you are redirected to `https://discourse.jujucharms.com/t/thoughts-on-unit-testing/1451`

- Go to `/t/thoughts-on-unit-testing/1451` and make sure you are redirected to `https://discourse.jujucharms.com/t/thoughts-on-unit-testing/1451`

- Go to `/thoughts-on-unit-testing` and make sure you see a 404
- Go to `/t/thoughts-on-unit-testing` and make sure you see a 404

- Feel free to try with other topics and also double check all still works fine for the docs category topics.