### PR TITLE
Redirect /help-google to /gce-cloud

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -148,3 +148,6 @@ upgrade-series: /upgrading-series
 users-sample-commands: /sample-command-usage-and-output-interpretation
 users: /user-types-and-abilities
 whats-new: /whats-new-2-6
+
+# Other redirects
+help-google/?: /gce-cloud


### PR DESCRIPTION
There's a link in the GUI to
https://jujucharms.com/docs/stable/help-google, which ultimately
redirects to https://docs.jujucharms.com/help-google which is
currently a 404.

This would point it to the correct page.

Helps with https://github.com/canonical-web-and-design/jaas.ai/issues/312

QA
--

`./run`, go to http://0.0.0.0:8033/help-google, see you end up at /gce-cloud.